### PR TITLE
Adds player ranking column

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,36 +1,14 @@
 import NextAuth from "next-auth";
-import type { DefaultSession, NextAuthOptions } from "next-auth";
+import type { NextAuthOptions } from "next-auth";
 import type { OAuthConfig } from "next-auth/providers/oauth";
 import type { JWT } from "next-auth/jwt";
 import { jwtDecode } from "jwt-decode";
-
-interface YahooProfile {
-  sub: string;
-  name?: string;
-  email?: string;
-  picture?: string;
-}
-
-interface YahooIdToken {
-  sub: string;
-  aud: string;
-  iss: string;
-  exp: number;
-  iat: number;
-}
-
-interface YahooTokens {
-  access_token: string;
-  refresh_token?: string;
-  expires_in: number;
-}
-
-interface ExtendedSession extends DefaultSession {
-  accessToken?: string;
-  refreshToken?: string;
-  expiresAt?: number;
-  error?: "RefreshAccessTokenError";
-}
+import type {
+  YahooProfile,
+  YahooIdToken,
+  YahooTokens,
+  ExtendedSession,
+} from "@/types/auth";
 
 declare module "next-auth" {
   interface Session {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,11 +18,20 @@ export default function Home() {
   const [season, setSeason] = React.useState('2025'); // Set 2025 as default
   
   // Update usePlayers with pagination
-  const { data: players, isLoading: isLoadingPlayers } = usePlayers({
+  const { data: playersData, isLoading: isLoadingPlayers } = usePlayers({
     season,
     start: pageIndex * 25, // 25 players per page
     count: 25
   });
+
+  // Add global rank to each player for proper sorting across pages
+  const players = React.useMemo(() => {
+    if (!playersData) return [];
+    return playersData.map((player, index) => ({
+      ...player,
+      globalRank: pageIndex * 25 + index + 1
+    }));
+  }, [playersData, pageIndex]);
 
   // Reset page when season changes
   React.useEffect(() => {

--- a/src/components/players-table/columns.tsx
+++ b/src/components/players-table/columns.tsx
@@ -8,6 +8,28 @@ import { PlayerStatsCell } from "@/components/players-table/player-stats-cell"
 
 export const columns: ColumnDef<YahooPlayerStats>[] = [
   {
+    id: "rank",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Rank" />
+    ),
+    cell: ({ row, table }) => {
+      // Calculate rank based on row index and current page
+      // Note: This assumes players are fetched in ranked order
+      const pageIndex = (table.options.meta as { pageIndex?: number })?.pageIndex || 0;
+      const pageSize = 25; // Players per page
+      const rank = pageIndex * pageSize + row.index + 1;
+      return <span className="font-medium text-sm">{rank}</span>;
+    },
+    accessorFn: (row, index) => {
+      // Return the calculated rank for sorting purposes
+      return index + 1; // This will be adjusted by the table's current page context
+    },
+    sortingFn: (rowA, rowB) => {
+      // Sort by the original row index to maintain rank order
+      return rowA.index - rowB.index;
+    },
+  },
+  {
     accessorKey: "name.full",
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Name" />

--- a/src/components/players-table/columns.tsx
+++ b/src/components/players-table/columns.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { ColumnDef } from "@tanstack/react-table"
-import { YahooPlayerStats } from "@/lib/yahoo-fantasy"
+import { YahooPlayerStats } from "@/types/yahoo-fantasy"
 import { DataTableColumnHeader } from "@/components/players-table/data-table-column-header"
 import { BATTING_STAT_IDS } from "@/lib/constants"
 import { PlayerStatsCell } from "@/components/players-table/player-stats-cell"

--- a/src/components/players-table/columns.tsx
+++ b/src/components/players-table/columns.tsx
@@ -5,30 +5,21 @@ import { YahooPlayerStats } from "@/types/yahoo-fantasy"
 import { DataTableColumnHeader } from "@/components/players-table/data-table-column-header"
 import { BATTING_STAT_IDS } from "@/lib/constants"
 import { PlayerStatsCell } from "@/components/players-table/player-stats-cell"
-import { DataTableMeta } from "@/types/table-pagination"
 
-export const columns: ColumnDef<YahooPlayerStats>[] = [
+// Extended player type with global rank
+type PlayerWithRank = YahooPlayerStats & { globalRank: number }
+
+export const columns: ColumnDef<PlayerWithRank>[] = [
   {
     id: "rank",
     header: ({ column }) => (
       <DataTableColumnHeader column={column} title="Rank" />
     ),
-    cell: ({ row, table }) => {
-      // Calculate rank based on row index and current page
-      // Note: This assumes players are fetched in ranked order
-      const meta = table.options.meta as DataTableMeta;
-      const pageIndex = meta?.pageIndex || 0;
-      const pageSize = meta?.pageSize || 25;
-      const rank = pageIndex * pageSize + row.index + 1;
+    accessorKey: "globalRank",
+    cell: ({ row }) => {
+      // Display the global rank that was calculated when data was fetched
+      const rank = row.original.globalRank;
       return <span className="font-medium text-sm">{rank}</span>;
-    },
-    accessorFn: (row, index) => {
-      // Return the calculated rank for sorting purposes
-      return index + 1; // This will be adjusted by the table's current page context
-    },
-    sortingFn: (rowA, rowB) => {
-      // Sort by the original row index to maintain rank order
-      return rowA.index - rowB.index;
     },
   },
   {

--- a/src/components/players-table/columns.tsx
+++ b/src/components/players-table/columns.tsx
@@ -5,6 +5,7 @@ import { YahooPlayerStats } from "@/types/yahoo-fantasy"
 import { DataTableColumnHeader } from "@/components/players-table/data-table-column-header"
 import { BATTING_STAT_IDS } from "@/lib/constants"
 import { PlayerStatsCell } from "@/components/players-table/player-stats-cell"
+import { DataTableMeta } from "@/types/table-pagination"
 
 export const columns: ColumnDef<YahooPlayerStats>[] = [
   {
@@ -15,8 +16,9 @@ export const columns: ColumnDef<YahooPlayerStats>[] = [
     cell: ({ row, table }) => {
       // Calculate rank based on row index and current page
       // Note: This assumes players are fetched in ranked order
-      const pageIndex = (table.options.meta as { pageIndex?: number })?.pageIndex || 0;
-      const pageSize = 25; // Players per page
+      const meta = table.options.meta as DataTableMeta;
+      const pageIndex = meta?.pageIndex || 0;
+      const pageSize = meta?.pageSize || 25;
       const rank = pageIndex * pageSize + row.index + 1;
       return <span className="font-medium text-sm">{rank}</span>;
     },

--- a/src/components/players-table/data-table.tsx
+++ b/src/components/players-table/data-table.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/table"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { DataTableMeta } from "@/types/table-pagination"
 
 interface DataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
@@ -29,6 +30,7 @@ interface DataTableProps<TData, TValue> {
   pageIndex?: number
   onPageChange?: (page: number) => void
   totalPages?: number
+  pageSize?: number
 }
 
 export function DataTable<TData, TValue>({
@@ -38,6 +40,7 @@ export function DataTable<TData, TValue>({
   pageIndex = 0,
   onPageChange,
   totalPages = 1,
+  pageSize = 25,
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([])
   const [globalFilter, setGlobalFilter] = React.useState("")
@@ -56,7 +59,8 @@ export function DataTable<TData, TValue>({
     },
     meta: {
       pageIndex,
-    },
+      pageSize,
+    } as DataTableMeta,
   })
 
   if (isLoading) {

--- a/src/components/players-table/data-table.tsx
+++ b/src/components/players-table/data-table.tsx
@@ -54,6 +54,9 @@ export function DataTable<TData, TValue>({
       sorting,
       globalFilter,
     },
+    meta: {
+      pageIndex,
+    },
   })
 
   if (isLoading) {
@@ -73,7 +76,7 @@ export function DataTable<TData, TValue>({
     <div className="space-y-4">
       <div className="flex items-center py-4">
         <Input
-          placeholder="Search all columns..."
+          placeholder="Search Player"
           value={globalFilter ?? ""}
           onChange={(event) => setGlobalFilter(event.target.value)}
           className="max-w-sm"

--- a/src/components/players-table/player-stats-cell.tsx
+++ b/src/components/players-table/player-stats-cell.tsx
@@ -1,4 +1,4 @@
-import { YahooPlayerStats } from '@/lib/yahoo-fantasy';
+import { YahooPlayerStats } from '@/types/yahoo-fantasy';
 
 interface PlayerStatsCellProps {
   player: YahooPlayerStats;

--- a/src/hooks/use-yahoo-fantasy.ts
+++ b/src/hooks/use-yahoo-fantasy.ts
@@ -1,12 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useSession, signOut } from 'next-auth/react';
 import { YahooFantasyAPI } from '@/lib/yahoo-fantasy';
-
-interface UsePlayersOptions {
-  season?: string;
-  start?: number;
-  count?: number;
-}
+import type { UsePlayersOptions } from '@/types/hooks';
 
 // Cache duration constants in milliseconds
 const CACHE_DURATIONS = {

--- a/src/lib/yahoo-fantasy.ts
+++ b/src/lib/yahoo-fantasy.ts
@@ -122,8 +122,6 @@ export class YahooFantasyAPI {
     return gameKey;
   }
 
-
-
   async getMLBPlayers(options: { season?: string; start?: number; count?: number; } = {}): Promise<YahooPlayerStats[]> {
     const { start = 0, count = 25 } = options;
     let { season } = options;

--- a/src/lib/yahoo-fantasy.ts
+++ b/src/lib/yahoo-fantasy.ts
@@ -1,80 +1,10 @@
 import axios from 'axios';
-
-interface YahooUserResponse {
-  fantasy_content: {
-    users: Array<{
-      user: Array<{
-        profile: {
-          display_name: string;
-          fantasy_profile_url: string;
-          image_url: string;
-        };
-      }>;
-    }>;
-  };
-}
-
-interface YahooGameKey {
-  game_key: string;
-  game_id: string;
-  name: string;
-  code: string;
-  type: string;
-  season: string;
-}
-
-interface YahooGamesResponse {
-  fantasy_content: {
-    games: Array<{
-      game: [YahooGameKey, unknown];
-    }>;
-  };
-}
-
-interface YahooPlayerStats {
-  player_key: string;
-  name: {
-    full: string;
-    first: string;
-    last: string;
-  };
-  editorial_team_abbr: string;
-  display_position: string;
-  player_stats?: {
-    stats: Array<{
-      stat_id: number;
-      value: string | number;
-    }>;
-  };
-}
-
-interface YahooPlayersResponse {
-  fantasy_content: {
-    game: [
-      unknown,
-      {
-        players: {
-          count: number;
-          [key: string]: {
-            player: [
-              Array<Record<string, unknown>>,
-              {
-                player_stats?: {
-                  stats: Array<{
-                    stat_id: number;
-                    value: string | number;
-                  }>;
-                };
-              }
-            ];
-          } | number;
-        };
-      }
-    ];
-  };
-}
-
-export type { YahooPlayerStats };
+import type {
+  YahooUserResponse,
+  YahooGamesResponse,
+  YahooPlayerStats,
+  YahooPlayersResponse,
+} from '@/types/yahoo-fantasy';
 
 export class YahooFantasyAPI {
   private accessToken: string;

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,29 @@
+export interface YahooProfile {
+  sub: string;
+  name?: string;
+  email?: string;
+  picture?: string;
+}
+
+export interface YahooIdToken {
+  sub: string;
+  aud: string;
+  iss: string;
+  exp: number;
+  iat: number;
+}
+
+export interface YahooTokens {
+  access_token: string;
+  refresh_token?: string;
+  expires_in: number;
+}
+
+import type { DefaultSession } from "next-auth";
+
+export interface ExtendedSession extends DefaultSession {
+  accessToken?: string;
+  refreshToken?: string;
+  expiresAt?: number;
+  error?: "RefreshAccessTokenError";
+} 

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,0 +1,5 @@
+export interface UsePlayersOptions {
+  season?: string;
+  start?: number;
+  count?: number;
+} 

--- a/src/types/table-pagination.ts
+++ b/src/types/table-pagination.ts
@@ -1,0 +1,4 @@
+export interface DataTableMeta {
+  pageIndex: number
+  pageSize: number
+} 

--- a/src/types/yahoo-fantasy.ts
+++ b/src/types/yahoo-fantasy.ts
@@ -1,0 +1,73 @@
+export interface YahooUserResponse {
+  fantasy_content: {
+    users: Array<{
+      user: Array<{
+        profile: {
+          display_name: string;
+          fantasy_profile_url: string;
+          image_url: string;
+        };
+      }>;
+    }>;
+  };
+}
+
+export interface YahooGameKey {
+  game_key: string;
+  game_id: string;
+  name: string;
+  code: string;
+  type: string;
+  season: string;
+}
+
+export interface YahooGamesResponse {
+  fantasy_content: {
+    games: Array<{
+      game: [YahooGameKey, unknown];
+    }>;
+  };
+}
+
+export interface YahooPlayerStats {
+  player_key: string;
+  name: {
+    full: string;
+    first: string;
+    last: string;
+  };
+  editorial_team_abbr: string;
+  display_position: string;
+  player_stats?: {
+    stats: Array<{
+      stat_id: number;
+      value: string | number;
+    }>;
+  };
+}
+
+export interface YahooPlayersResponse {
+  fantasy_content: {
+    game: [
+      unknown,
+      {
+        players: {
+          count: number;
+          [key: string]: {
+            player: [
+              Array<Record<string, unknown>>,
+              {
+                player_stats?: {
+                  stats: Array<{
+                    stat_id: number;
+                    value: string | number;
+                  }>;
+                };
+              }
+            ];
+          } | number;
+        };
+      }
+    ];
+  };
+} 


### PR DESCRIPTION
# Add Player Ranking Column

Added a sortable ranking column to the players table that shows each player's Yahoo Fantasy ranking position (1st, 2nd, 3rd, etc.).

## What Changed
- **New Rank Column**: First column now displays player rankings
- **Proper Sorting**: Clicking the rank header sorts players by their actual ranking across all pages
- **Pagination Support**: Rankings work correctly when browsing through pages (1-25, 26-50, etc.)

## User Benefits
- **Quick Identification**: Easily see which players are top-ranked
- **Better Decision Making**: Sort by rank to find the best available players
- **Consistent Experience**: Rankings maintain proper order across all pages

## Technical Notes
- Addresses code quality issues identified in review
- Improves type safety and removes hardcoded values
- Maintains backward compatibility

## Screenshot
<img width="1714" alt="image" src="https://github.com/user-attachments/assets/a62ea56d-7940-4953-aa78-5dfd09fa9730" />