### PR TITLE
Add Zod validation for external data boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,8 +35,9 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-# Override global gitignore for src/lib
+# Override global gitignore for lib directories
 !src/lib/
+!src/__tests__/lib/
 
 # SWC compiler cache
 .swc/

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
+# Override global gitignore for src/lib
+!src/lib/
+
 # SWC compiler cache
 .swc/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,10 @@ For complete project context, see [AGENTS.md](./AGENTS.md)
 ### Working with Yahoo Fantasy API
 1. **Always verify endpoint exists** in official docs first: https://developer.yahoo.com/fantasysports/guide/
 2. Add method to `YahooFantasyAPI` class in `/lib/yahoo-fantasy.ts`
-3. Create Zod schema in `/lib/schemas/` for the API response
-4. Add TanStack Query hook to `/hooks/use-yahoo-fantasy.ts`
-5. Use hook in component with proper loading/error states
+3. Create Zod schema in `/lib/schemas/` for the API response (use `.passthrough()` for permissive validation)
+4. Use `requestWithValidation()` method to validate responses
+5. Add TanStack Query hook to `/hooks/use-yahoo-fantasy.ts`
+6. Use hook in component with proper loading/error states
 
 ### Creating Data Tables
 - Reference `/components/players-table/` for implementation patterns
@@ -40,4 +41,14 @@ For complete project context, see [AGENTS.md](./AGENTS.md)
 
 3. **All Yahoo API calls go through `/api/yahoo` proxy** - Never call `https://fantasysports.yahooapis.com` directly from client code
 
-4. **Use Zod only for external data boundaries** - API responses, OAuth tokens, user input, env vars. Use TypeScript interfaces for component props and internal logic
+4. **Use Zod only for external data boundaries** - API responses, OAuth tokens, env vars. Use TypeScript interfaces for component props and internal logic
+
+5. **Zod schemas use `.passthrough()`** - Yahoo API may return additional fields; never use `.strict()`
+
+## Zod Schema Locations
+
+- `src/lib/schemas/games.ts` - MLB game key responses
+- `src/lib/schemas/users.ts` - User profile responses
+- `src/lib/schemas/players.ts` - Player stats responses
+- `src/lib/schemas/auth.ts` - OAuth tokens and JWT validation
+- `src/lib/schemas/env.ts` - Environment variable validation

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,9 +24,11 @@ const customJestConfig = {
     '!src/app/globals.css',
     '!src/__tests__/utils/**',
     '!src/app/api/auth/**',
+    '!src/app/api/dev/**',
     '!src/lib/utils.ts',
     '!src/lib/constants.ts',
     '!src/lib/auth.ts',
+    '!src/lib/schemas/dev-logger.ts',
   ],
   testMatch: [
     '<rootDir>/src/**/__tests__/**/*.{test,spec}.{js,jsx,ts,tsx}',

--- a/src/__tests__/app/api/yahoo/route.test.ts
+++ b/src/__tests__/app/api/yahoo/route.test.ts
@@ -143,7 +143,8 @@ describe('Yahoo API Route', () => {
     expect(mockNextResponseJson).toHaveBeenCalledWith(
       {
         error: 'Failed to fetch from Yahoo API',
-        details: { error: { description: 'Invalid token' } }
+        message: { error: { description: 'Invalid token' } },
+        statusCode: 401
       },
       { status: 401 }
     )
@@ -156,7 +157,8 @@ describe('Yahoo API Route', () => {
     expect(mockNextResponseJson).toHaveBeenCalledWith(
       {
         error: 'Failed to fetch from Yahoo API',
-        details: 'Network Error'
+        message: 'Network Error',
+        statusCode: 500
       },
       { status: 500 }
     )
@@ -165,7 +167,11 @@ describe('Yahoo API Route', () => {
     mockAxiosGet.mockRejectedValue(new Error('Unexpected error'))
     await GET(request)
     expect(mockNextResponseJson).toHaveBeenCalledWith(
-      { error: 'An unexpected error occurred' },
+      {
+        error: 'An unexpected error occurred',
+        message: 'Unexpected error',
+        statusCode: 500
+      },
       { status: 500 }
     )
   })

--- a/src/__tests__/fixtures/yahoo-responses.json
+++ b/src/__tests__/fixtures/yahoo-responses.json
@@ -1,0 +1,337 @@
+{
+  "description": "Real Yahoo Fantasy API responses for schema building and tests",
+  "captured": "2026-01-26",
+  "games": {
+    "endpoint": "/games;game_codes=mlb;seasons=2026",
+    "response": {
+      "fantasy_content": {
+        "xml:lang": "en-US",
+        "yahoo:uri": "/fantasy/v2/games;game_codes=mlb;seasons=2026",
+        "games": {
+          "0": {
+            "game": [
+              {
+                "game_key": "469",
+                "game_id": "469",
+                "name": "Baseball",
+                "code": "mlb",
+                "type": "full",
+                "url": "https://baseball.fantasysports.yahoo.com/b1",
+                "season": "2026",
+                "is_registration_over": 0,
+                "is_game_over": 0,
+                "is_offseason": 0,
+                "alternate_start_deadline": "2025-03-26"
+              }
+            ]
+          },
+          "count": 1
+        },
+        "time": "20.323038101196ms",
+        "copyright": "Certain Data by Sportradar, Stats Perform and Rotowire",
+        "refresh_rate": "60"
+      }
+    }
+  },
+  "users": {
+    "endpoint": "/users;use_login=1/profile",
+    "response": {
+      "fantasy_content": {
+        "xml:lang": "en-US",
+        "yahoo:uri": "/fantasy/v2/users;use_login=1/profile",
+        "users": {
+          "0": {
+            "user": [
+              {
+                "guid": "POHFU3YUU7RLLDQ24SH4WBSJHA"
+              },
+              {
+                "profile": {
+                  "display_name": "Juan",
+                  "fantasy_profile_url": "https://profiles.sports.yahoo.com/user/POHFU3YUU7RLLDQ24SH4WBSJHA",
+                  "legal_jurisdiction": "us",
+                  "image_url": "https://s.yimg.com/ag/images/7a032fc5-401b-4349-950a-c23f539f51bf_64sq.jpg",
+                  "unique_username": "Juan-V3MJK"
+                }
+              }
+            ]
+          },
+          "count": 1
+        },
+        "time": "35.269021987915ms",
+        "copyright": "Certain Data by Sportradar, Stats Perform and Rotowire",
+        "refresh_rate": "60"
+      }
+    }
+  },
+  "players": {
+    "endpoint": "/game/469/players;start=0;count=25;sort=AR;status=A;position=B/stats",
+    "response": {
+      "fantasy_content": {
+        "xml:lang": "en-US",
+        "yahoo:uri": "/fantasy/v2/game/469/players;start=0;count=25;sort=AR;status=A;position=B/stats",
+        "game": [
+          {
+            "game_key": "469",
+            "game_id": "469",
+            "name": "Baseball",
+            "code": "mlb",
+            "type": "full",
+            "url": "https://baseball.fantasysports.yahoo.com/b1",
+            "season": "2026",
+            "is_registration_over": 0,
+            "is_game_over": 0,
+            "is_offseason": 0,
+            "alternate_start_deadline": "2025-03-26"
+          },
+          {
+            "players": {
+              "0": {
+                "player": [
+                  [
+                    { "player_key": "469.p.9877" },
+                    { "player_id": "9877" },
+                    {
+                      "name": {
+                        "full": "Aaron Judge",
+                        "first": "Aaron",
+                        "last": "Judge",
+                        "ascii_first": "Aaron",
+                        "ascii_last": "Judge"
+                      }
+                    },
+                    { "url": "https://sports.yahoo.com/mlb/players/9877" },
+                    { "editorial_player_key": "mlb.p.9877" },
+                    { "editorial_team_key": "mlb.t.10" },
+                    { "editorial_team_full_name": "New York Yankees" },
+                    { "editorial_team_abbr": "NYY" },
+                    { "editorial_team_url": "https://sports.yahoo.com/mlb/teams/ny-yankees/" },
+                    { "is_keeper": { "status": false, "cost": false } },
+                    { "uniform_number": "99" },
+                    { "display_position": "OF" },
+                    {
+                      "headshot": {
+                        "url": "https://s.yimg.com/iu/api/res/1.2/e9N9NOYZ6tnzXWKhouccxQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04042025/9877.png",
+                        "size": "small"
+                      },
+                      "image_url": "https://s.yimg.com/iu/api/res/1.2/e9N9NOYZ6tnzXWKhouccxQ--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04042025/9877.png"
+                    },
+                    { "is_undroppable": "0" },
+                    { "position_type": "B" },
+                    [],
+                    {
+                      "eligible_positions": [
+                        { "position": "CF" },
+                        { "position": "LF" },
+                        { "position": "OF" },
+                        { "position": "RF" }
+                      ]
+                    },
+                    { "eligible_positions_to_add": [] },
+                    [],
+                    [],
+                    { "has_player_notes": 1 },
+                    [],
+                    []
+                  ],
+                  {
+                    "player_stats": {
+                      "0": { "coverage_type": "season", "season": "2026" },
+                      "stats": [
+                        { "stat": { "stat_id": "0", "value": "-" } },
+                        { "stat": { "stat_id": "1", "value": "-" } },
+                        { "stat": { "stat_id": "2", "value": "-" } },
+                        { "stat": { "stat_id": "6", "value": "-" } },
+                        { "stat": { "stat_id": "7", "value": "-" } },
+                        { "stat": { "stat_id": "8", "value": "-" } },
+                        { "stat": { "stat_id": "9", "value": "-" } },
+                        { "stat": { "stat_id": "10", "value": "-" } },
+                        { "stat": { "stat_id": "11", "value": "-" } },
+                        { "stat": { "stat_id": "12", "value": "-" } },
+                        { "stat": { "stat_id": "13", "value": "-" } },
+                        { "stat": { "stat_id": "14", "value": "-" } },
+                        { "stat": { "stat_id": "15", "value": "-" } },
+                        { "stat": { "stat_id": "16", "value": "-" } },
+                        { "stat": { "stat_id": "17", "value": "-" } },
+                        { "stat": { "stat_id": "18", "value": "-" } },
+                        { "stat": { "stat_id": "19", "value": "-" } },
+                        { "stat": { "stat_id": "20", "value": "-" } },
+                        { "stat": { "stat_id": "21", "value": "-" } },
+                        { "stat": { "stat_id": "22", "value": "-" } },
+                        { "stat": { "stat_id": "23", "value": "-" } },
+                        { "stat": { "stat_id": "51", "value": "-" } },
+                        { "stat": { "stat_id": "52", "value": "-" } },
+                        { "stat": { "stat_id": "53", "value": "-" } },
+                        { "stat": { "stat_id": "54", "value": "-" } },
+                        { "stat": { "stat_id": "3", "value": "-" } },
+                        { "stat": { "stat_id": "4", "value": "-" } },
+                        { "stat": { "stat_id": "5", "value": "-" } },
+                        { "stat": { "stat_id": "55", "value": "-" } },
+                        { "stat": { "stat_id": "58", "value": "-" } },
+                        { "stat": { "stat_id": "59", "value": "-" } },
+                        { "stat": { "stat_id": "61", "value": "-" } },
+                        { "stat": { "stat_id": "62", "value": "-" } },
+                        { "stat": { "stat_id": "63", "value": "-" } },
+                        { "stat": { "stat_id": "64", "value": "-" } },
+                        { "stat": { "stat_id": "65", "value": "-" } },
+                        { "stat": { "stat_id": "66", "value": "-" } },
+                        { "stat": { "stat_id": "86", "value": "-" } },
+                        { "stat": { "stat_id": "87", "value": "-" } },
+                        { "stat": { "stat_id": "88", "value": "-" } }
+                      ]
+                    },
+                    "player_advanced_stats": {
+                      "0": { "coverage_type": "season", "season": "2026" },
+                      "stats": [
+                        { "stat": { "stat_id": "1035", "value": "-" } },
+                        { "stat": { "stat_id": "1008", "value": "-" } },
+                        { "stat": { "stat_id": "1013", "value": "-" } },
+                        { "stat": { "stat_id": "1002", "value": "-" } },
+                        { "stat": { "stat_id": "1014", "value": "-" } },
+                        { "stat": { "stat_id": "1015", "value": "-" } },
+                        { "stat": { "stat_id": "1011", "value": "-" } },
+                        { "stat": { "stat_id": "1005", "value": "-" } },
+                        { "stat": { "stat_id": "1006", "value": "-" } },
+                        { "stat": { "stat_id": "1009", "value": "-" } },
+                        { "stat": { "stat_id": "1007", "value": "-" } },
+                        { "stat": { "stat_id": "1010", "value": "-" } },
+                        { "stat": { "stat_id": "1004", "value": "-" } },
+                        { "stat": { "stat_id": "1039", "value": "-" } },
+                        { "stat": { "stat_id": "1003", "value": "-" } },
+                        { "stat": { "stat_id": "1040", "value": "-" } },
+                        { "stat": { "stat_id": "1041", "value": "-" } }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "1": {
+                "player": [
+                  [
+                    { "player_key": "469.p.9190" },
+                    { "player_id": "9190" },
+                    {
+                      "name": {
+                        "full": "Donovan Solano",
+                        "first": "Donovan",
+                        "last": "Solano",
+                        "ascii_first": "Donovan",
+                        "ascii_last": "Solano"
+                      }
+                    },
+                    { "url": "https://sports.yahoo.com/mlb/players/9190" },
+                    { "status": "NA", "status_full": "Not Active" },
+                    { "editorial_player_key": "mlb.p.9190" },
+                    { "editorial_team_key": "mlb.t.13" },
+                    { "editorial_team_full_name": "Texas Rangers" },
+                    { "editorial_team_abbr": "TEX" },
+                    { "editorial_team_url": "https://sports.yahoo.com/mlb/teams/texas/" },
+                    { "is_keeper": { "status": false, "cost": false } },
+                    { "uniform_number": "16" },
+                    { "display_position": "1B" },
+                    {
+                      "headshot": {
+                        "url": "https://s.yimg.com/iu/api/res/1.2/6wRSaAVEHutlAeumpVBYxw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04032025/9190.1.png",
+                        "size": "small"
+                      },
+                      "image_url": "https://s.yimg.com/iu/api/res/1.2/6wRSaAVEHutlAeumpVBYxw--~C/YXBwaWQ9eXNwb3J0cztjaD0yMzM2O2NyPTE7Y3c9MTc5MDtkeD04NTc7ZHk9MDtmaT11bGNyb3A7aD02MDtxPTEwMDt3PTQ2/https://s.yimg.com/xe/i/us/sp/v/mlb_cutout/players_l/04032025/9190.1.png"
+                    },
+                    { "is_undroppable": "0" },
+                    { "position_type": "B" },
+                    [],
+                    {
+                      "eligible_positions": [
+                        { "position": "1B" },
+                        { "position": "CI" },
+                        { "position": "IF" }
+                      ]
+                    },
+                    { "eligible_positions_to_add": [] },
+                    [],
+                    [],
+                    [],
+                    [],
+                    []
+                  ],
+                  {
+                    "player_stats": {
+                      "0": { "coverage_type": "season", "season": "2026" },
+                      "stats": [
+                        { "stat": { "stat_id": "0", "value": "-" } },
+                        { "stat": { "stat_id": "1", "value": "-" } },
+                        { "stat": { "stat_id": "2", "value": "-" } },
+                        { "stat": { "stat_id": "6", "value": "-" } },
+                        { "stat": { "stat_id": "7", "value": "-" } },
+                        { "stat": { "stat_id": "8", "value": "-" } },
+                        { "stat": { "stat_id": "9", "value": "-" } },
+                        { "stat": { "stat_id": "10", "value": "-" } },
+                        { "stat": { "stat_id": "11", "value": "-" } },
+                        { "stat": { "stat_id": "12", "value": "-" } },
+                        { "stat": { "stat_id": "13", "value": "-" } },
+                        { "stat": { "stat_id": "14", "value": "-" } },
+                        { "stat": { "stat_id": "15", "value": "-" } },
+                        { "stat": { "stat_id": "16", "value": "-" } },
+                        { "stat": { "stat_id": "17", "value": "-" } },
+                        { "stat": { "stat_id": "18", "value": "-" } },
+                        { "stat": { "stat_id": "19", "value": "-" } },
+                        { "stat": { "stat_id": "20", "value": "-" } },
+                        { "stat": { "stat_id": "21", "value": "-" } },
+                        { "stat": { "stat_id": "22", "value": "-" } },
+                        { "stat": { "stat_id": "23", "value": "-" } },
+                        { "stat": { "stat_id": "51", "value": "-" } },
+                        { "stat": { "stat_id": "52", "value": "-" } },
+                        { "stat": { "stat_id": "53", "value": "-" } },
+                        { "stat": { "stat_id": "54", "value": "-" } },
+                        { "stat": { "stat_id": "3", "value": "-" } },
+                        { "stat": { "stat_id": "4", "value": "-" } },
+                        { "stat": { "stat_id": "5", "value": "-" } },
+                        { "stat": { "stat_id": "55", "value": "-" } },
+                        { "stat": { "stat_id": "58", "value": "-" } },
+                        { "stat": { "stat_id": "59", "value": "-" } },
+                        { "stat": { "stat_id": "61", "value": "-" } },
+                        { "stat": { "stat_id": "62", "value": "-" } },
+                        { "stat": { "stat_id": "63", "value": "-" } },
+                        { "stat": { "stat_id": "64", "value": "-" } },
+                        { "stat": { "stat_id": "65", "value": "-" } },
+                        { "stat": { "stat_id": "66", "value": "-" } },
+                        { "stat": { "stat_id": "86", "value": "-" } },
+                        { "stat": { "stat_id": "87", "value": "-" } },
+                        { "stat": { "stat_id": "88", "value": "-" } }
+                      ]
+                    },
+                    "player_advanced_stats": {
+                      "0": { "coverage_type": "season", "season": "2026" },
+                      "stats": [
+                        { "stat": { "stat_id": "1035", "value": "-" } },
+                        { "stat": { "stat_id": "1008", "value": "-" } },
+                        { "stat": { "stat_id": "1013", "value": "-" } },
+                        { "stat": { "stat_id": "1002", "value": "-" } },
+                        { "stat": { "stat_id": "1014", "value": "-" } },
+                        { "stat": { "stat_id": "1015", "value": "-" } },
+                        { "stat": { "stat_id": "1011", "value": "-" } },
+                        { "stat": { "stat_id": "1005", "value": "-" } },
+                        { "stat": { "stat_id": "1006", "value": "-" } },
+                        { "stat": { "stat_id": "1009", "value": "-" } },
+                        { "stat": { "stat_id": "1007", "value": "-" } },
+                        { "stat": { "stat_id": "1010", "value": "-" } },
+                        { "stat": { "stat_id": "1004", "value": "-" } },
+                        { "stat": { "stat_id": "1039", "value": "-" } },
+                        { "stat": { "stat_id": "1003", "value": "-" } },
+                        { "stat": { "stat_id": "1040", "value": "-" } },
+                        { "stat": { "stat_id": "1041", "value": "-" } }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "count": 2
+            }
+          }
+        ],
+        "time": "150.12345ms",
+        "copyright": "Certain Data by Sportradar, Stats Perform and Rotowire",
+        "refresh_rate": "60"
+      }
+    }
+  }
+}

--- a/src/__tests__/hooks/use-yahoo-fantasy.test.tsx
+++ b/src/__tests__/hooks/use-yahoo-fantasy.test.tsx
@@ -214,12 +214,12 @@ describe('useYahooFantasy', () => {
       wrapper: createWrapper,
     })
 
-    // Hooks should return error states
-    expect(userInfoResult.result.current.data).toBeNull()
+    // Hooks should return error states (undefined, not null)
+    expect(userInfoResult.result.current.data).toBeUndefined()
     expect(userInfoResult.result.current.error).toEqual(new Error('Session expired'))
-    expect(playersResult.result.current.data).toBeNull()
+    expect(playersResult.result.current.data).toBeUndefined()
     expect(playersResult.result.current.error).toEqual(new Error('Session expired'))
-    expect(playersComprehensiveResult.result.current.data).toBeNull()
+    expect(playersComprehensiveResult.result.current.data).toBeUndefined()
     expect(playersComprehensiveResult.result.current.error).toEqual(new Error('Session expired'))
   })
 

--- a/src/__tests__/lib/schemas/auth.test.ts
+++ b/src/__tests__/lib/schemas/auth.test.ts
@@ -1,0 +1,152 @@
+import {
+  yahooIdTokenSchema,
+  yahooTokenResponseSchema,
+  yahooTokenErrorSchema,
+  parseYahooTokenResponse,
+} from '@/lib/schemas/auth';
+
+describe('Auth Schemas', () => {
+  describe('yahooIdTokenSchema', () => {
+    it('should validate valid ID token payload', () => {
+      const validToken = {
+        sub: 'user123',
+        aud: 'client-id',
+        iss: 'https://api.login.yahoo.com',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iat: Math.floor(Date.now() / 1000),
+      };
+
+      const result = yahooIdTokenSchema.safeParse(validToken);
+      expect(result.success).toBe(true);
+    });
+
+    it('should allow additional fields with passthrough', () => {
+      const tokenWithExtra = {
+        sub: 'user123',
+        aud: 'client-id',
+        iss: 'https://api.login.yahoo.com',
+        exp: 1234567890,
+        iat: 1234567800,
+        email: 'user@example.com',
+        name: 'Test User',
+      };
+
+      const result = yahooIdTokenSchema.safeParse(tokenWithExtra);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.email).toBe('user@example.com');
+      }
+    });
+
+    it('should reject invalid ID token', () => {
+      const invalidToken = {
+        sub: 'user123',
+        // missing required fields
+      };
+
+      const result = yahooIdTokenSchema.safeParse(invalidToken);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('yahooTokenResponseSchema', () => {
+    it('should validate valid token response', () => {
+      const validResponse = {
+        access_token: 'abc123',
+        refresh_token: 'refresh456',
+        expires_in: 3600,
+        token_type: 'bearer',
+      };
+
+      const result = yahooTokenResponseSchema.safeParse(validResponse);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate minimal token response', () => {
+      const minimalResponse = {
+        access_token: 'abc123',
+        expires_in: 3600,
+      };
+
+      const result = yahooTokenResponseSchema.safeParse(minimalResponse);
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject response without access_token', () => {
+      const invalidResponse = {
+        refresh_token: 'refresh456',
+        expires_in: 3600,
+      };
+
+      const result = yahooTokenResponseSchema.safeParse(invalidResponse);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('yahooTokenErrorSchema', () => {
+    it('should validate error response', () => {
+      const errorResponse = {
+        error: 'invalid_grant',
+        error_description: 'Token has expired',
+      };
+
+      const result = yahooTokenErrorSchema.safeParse(errorResponse);
+      expect(result.success).toBe(true);
+    });
+
+    it('should validate error without description', () => {
+      const errorResponse = {
+        error: 'access_denied',
+      };
+
+      const result = yahooTokenErrorSchema.safeParse(errorResponse);
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('parseYahooTokenResponse', () => {
+    it('should return success for valid token response', () => {
+      const validResponse = {
+        access_token: 'abc123',
+        refresh_token: 'refresh456',
+        expires_in: 3600,
+      };
+
+      const result = parseYahooTokenResponse(validResponse);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.tokens.access_token).toBe('abc123');
+      }
+    });
+
+    it('should return error for error response', () => {
+      const errorResponse = {
+        error: 'invalid_grant',
+        error_description: 'Token has expired',
+      };
+
+      const result = parseYahooTokenResponse(errorResponse);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.error).toBe('invalid_grant');
+      }
+    });
+
+    it('should return error for invalid response format', () => {
+      const invalidResponse = {
+        random: 'data',
+      };
+
+      const result = parseYahooTokenResponse(invalidResponse);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.error).toBe('invalid_response');
+      }
+    });
+
+    it('should handle null/undefined input', () => {
+      const result = parseYahooTokenResponse(null);
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/__tests__/lib/schemas/env.test.ts
+++ b/src/__tests__/lib/schemas/env.test.ts
@@ -1,0 +1,68 @@
+import { validateEnv } from '@/lib/schemas/env';
+
+describe('Env Schema', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('validateEnv', () => {
+    it('should validate complete environment', () => {
+      process.env = {
+        ...process.env,
+        NEXTAUTH_URL: 'https://example.com',
+        NEXTAUTH_SECRET: 'super-secret-key',
+        YAHOO_CLIENT_ID: 'client-id-123',
+        YAHOO_CLIENT_SECRET: 'client-secret-456',
+        NODE_ENV: 'test',
+      };
+
+      const result = validateEnv();
+      expect(result.NEXTAUTH_URL).toBe('https://example.com');
+      expect(result.NEXTAUTH_SECRET).toBe('super-secret-key');
+      expect(result.YAHOO_CLIENT_ID).toBe('client-id-123');
+      expect(result.YAHOO_CLIENT_SECRET).toBe('client-secret-456');
+      expect(result.NODE_ENV).toBe('test');
+    });
+
+    it('should throw on missing required env vars', () => {
+      process.env = {
+        NODE_ENV: 'test',
+        // Missing all required vars
+      };
+
+      expect(() => validateEnv()).toThrow('Missing or invalid environment variables');
+    });
+
+    it('should throw on invalid NEXTAUTH_URL', () => {
+      process.env = {
+        ...process.env,
+        NEXTAUTH_URL: 'not-a-url',
+        NEXTAUTH_SECRET: 'secret',
+        YAHOO_CLIENT_ID: 'id',
+        YAHOO_CLIENT_SECRET: 'secret',
+      };
+
+      expect(() => validateEnv()).toThrow();
+    });
+
+    it('should default NODE_ENV to development', () => {
+      process.env = {
+        NEXTAUTH_URL: 'https://example.com',
+        NEXTAUTH_SECRET: 'secret',
+        YAHOO_CLIENT_ID: 'id',
+        YAHOO_CLIENT_SECRET: 'secret',
+      } as unknown as NodeJS.ProcessEnv;
+
+      const result = validateEnv();
+      expect(result.NODE_ENV).toBe('development');
+    });
+  });
+
+});

--- a/src/__tests__/utils/test-fixtures.ts
+++ b/src/__tests__/utils/test-fixtures.ts
@@ -1,14 +1,8 @@
 import { BATTING_STAT_IDS, PITCHING_STAT_IDS } from '@/lib/constants'
-import type { 
-  YahooUserResponse, 
-  YahooPlayerStats, 
-  YahooPlayersResponse,
-  YahooGamesResponse,
-  PlayerWithRank 
-} from '@/types/yahoo-fantasy'
+import type { YahooPlayerStats, PlayerWithRank } from '@/types/yahoo-fantasy'
 
-// Mock User Data
-export const mockUserInfo: YahooUserResponse = {
+// Mock User Data (simplified structure for tests)
+export const mockUserInfo = {
   fantasy_content: {
     users: [{
       user: [
@@ -138,8 +132,8 @@ export const mockPitchersWithRank: PlayerWithRank[] = mockPitchers.map((player, 
   globalRank: index + 1
 }))
 
-// Mock API Response
-export const mockPlayersResponse: YahooPlayersResponse = {
+// Mock API Response (simplified structure for tests)
+export const mockPlayersResponse = {
   fantasy_content: {
     game: [
       {},
@@ -241,8 +235,8 @@ export const createMockPlayerWithRank = (overrides: Partial<PlayerWithRank> = {}
   ...overrides
 })
 
-// Mock Game Response (for Yahoo API tests)
-export const mockGameResponse: YahooGamesResponse = {
+// Mock Game Response (simplified structure for tests)
+export const mockGameResponse = {
   fantasy_content: {
     games: [
       {

--- a/src/__tests__/utils/test-fixtures.ts
+++ b/src/__tests__/utils/test-fixtures.ts
@@ -1,21 +1,24 @@
 import { BATTING_STAT_IDS, PITCHING_STAT_IDS } from '@/lib/constants'
 import type { YahooPlayerStats, PlayerWithRank } from '@/types/yahoo-fantasy'
 
-// Mock User Data (simplified structure for tests)
+// Mock User Data (matches real Yahoo API structure with numeric keys)
 export const mockUserInfo = {
   fantasy_content: {
-    users: [{
-      user: [
-        {}, // First element is typically empty in Yahoo API
-        {
-          profile: {
-            display_name: 'Test User',
-            fantasy_profile_url: 'https://example.com',
-            image_url: 'https://example.com/avatar.jpg'
+    users: {
+      count: 1,
+      "0": {
+        user: [
+          { guid: 'test-user-guid' },
+          {
+            profile: {
+              display_name: 'Test User',
+              fantasy_profile_url: 'https://example.com',
+              image_url: 'https://example.com/avatar.jpg'
+            }
           }
-        }
-      ]
-    }]
+        ]
+      }
+    }
   }
 }
 
@@ -132,14 +135,32 @@ export const mockPitchersWithRank: PlayerWithRank[] = mockPitchers.map((player, 
   globalRank: index + 1
 }))
 
-// Mock API Response (simplified structure for tests)
+// Game info for players response
+const mockGameInfo = {
+  game_key: '431',
+  game_id: '431',
+  name: 'Baseball',
+  code: 'mlb',
+  type: 'full',
+  url: 'https://baseball.fantasysports.yahoo.com/b1',
+  season: '2025',
+  is_registration_over: 0,
+  is_game_over: 0,
+  is_offseason: 0
+};
+
+// Helper to wrap stats in Yahoo's { stat: {...} } format
+const wrapStats = (stats: Array<{ stat_id: number; value: string | number }>) =>
+  stats.map(s => ({ stat: { stat_id: String(s.stat_id), value: s.value } }));
+
+// Mock API Response (matches real Yahoo API structure)
 export const mockPlayersResponse = {
   fantasy_content: {
     game: [
-      {},
+      mockGameInfo,
       {
         players: {
-          count: mockPlayers.length,
+          count: 2,
           "0": {
             player: [
               [
@@ -149,7 +170,9 @@ export const mockPlayersResponse = {
                 { display_position: mockPlayers[0].display_position }
               ],
               {
-                player_stats: mockPlayers[0].player_stats
+                player_stats: {
+                  stats: wrapStats(mockPlayers[0].player_stats?.stats || [])
+                }
               }
             ]
           },
@@ -162,7 +185,9 @@ export const mockPlayersResponse = {
                 { display_position: mockPlayers[1].display_position }
               ],
               {
-                player_stats: mockPlayers[1].player_stats
+                player_stats: {
+                  stats: wrapStats(mockPlayers[1].player_stats?.stats || [])
+                }
               }
             ]
           }
@@ -235,11 +260,12 @@ export const createMockPlayerWithRank = (overrides: Partial<PlayerWithRank> = {}
   ...overrides
 })
 
-// Mock Game Response (simplified structure for tests)
+// Mock Game Response (matches real Yahoo API structure with numeric keys)
 export const mockGameResponse = {
   fantasy_content: {
-    games: [
-      {
+    games: {
+      count: 1,
+      "0": {
         game: [
           {
             game_key: '431',
@@ -247,12 +273,15 @@ export const mockGameResponse = {
             name: 'Baseball',
             code: 'mlb',
             type: 'full',
-            season: '2025'
-          },
-          {}
+            url: 'https://baseball.fantasysports.yahoo.com/b1',
+            season: '2025',
+            is_registration_over: 0,
+            is_game_over: 0,
+            is_offseason: 0
+          }
         ]
       }
-    ]
+    }
   }
 }
 
@@ -295,20 +324,23 @@ export const mockGenericErrorData = {
   error: 'An unexpected error occurred'
 }
 
-// Mock successful Yahoo API response data
+// Mock successful Yahoo API response data (matches real structure)
 export const mockYahooAPISuccessData = {
   fantasy_content: {
-    users: [{
-      user: [
-        {},
-        {
-          profile: {
-            display_name: 'Test User',
-            fantasy_profile_url: 'https://example.com',
-            image_url: 'https://example.com/avatar.jpg'
+    users: {
+      count: 1,
+      "0": {
+        user: [
+          { guid: 'test-user-guid' },
+          {
+            profile: {
+              display_name: 'Test User',
+              fantasy_profile_url: 'https://example.com',
+              image_url: 'https://example.com/avatar.jpg'
+            }
           }
-        }
-      ]
-    }]
+        ]
+      }
+    }
   }
 } 

--- a/src/__tests__/utils/test-helpers.ts
+++ b/src/__tests__/utils/test-helpers.ts
@@ -1,5 +1,20 @@
+// Game info for players response (matches real Yahoo API)
+const mockGameInfo = {
+  game_key: '431',
+  game_id: '431',
+  name: 'Baseball',
+  code: 'mlb',
+  type: 'full',
+  url: 'https://baseball.fantasysports.yahoo.com/b1',
+  season: '2025',
+  is_registration_over: 0,
+  is_game_over: 0,
+  is_offseason: 0
+};
+
 /**
  * Helper function to create mock Yahoo Players API response
+ * Matches real Yahoo API structure with wrapped stats
  * @param count - Number of players in the response
  * @param playerData - Array of player data objects
  * @returns Properly formatted players response structure
@@ -19,6 +34,11 @@ export const createMockPlayersResponse = (count: number, playerData: Array<{
   const players: Record<string, unknown> = { count };
 
   playerData.forEach((player, index) => {
+    // Wrap stats in { stat: {...} } format like real Yahoo API
+    const wrappedStats = player.player_stats?.stats.map(s => ({
+      stat: { stat_id: String(s.stat_id), value: s.value }
+    })) || [];
+
     players[index.toString()] = {
       player: [
         [
@@ -28,7 +48,9 @@ export const createMockPlayersResponse = (count: number, playerData: Array<{
           { display_position: player.display_position }
         ],
         {
-          player_stats: player.player_stats
+          player_stats: {
+            stats: wrappedStats
+          }
         }
       ]
     };
@@ -37,7 +59,7 @@ export const createMockPlayersResponse = (count: number, playerData: Array<{
   return {
     fantasy_content: {
       game: [
-        {},
+        mockGameInfo,
         { players }
       ]
     }
@@ -51,7 +73,7 @@ export const createMockPlayersResponse = (count: number, playerData: Array<{
 export const createEmptyPlayersResponse = () => ({
   fantasy_content: {
     game: [
-      {},
+      mockGameInfo,
       { players: { count: 0 } }
     ]
   }

--- a/src/__tests__/utils/test-helpers.ts
+++ b/src/__tests__/utils/test-helpers.ts
@@ -1,10 +1,8 @@
-import type { YahooPlayersResponse } from '@/types/yahoo-fantasy'
-
 /**
  * Helper function to create mock Yahoo Players API response
  * @param count - Number of players in the response
  * @param playerData - Array of player data objects
- * @returns Properly formatted YahooPlayersResponse
+ * @returns Properly formatted players response structure
  */
 export const createMockPlayersResponse = (count: number, playerData: Array<{
   player_key: string;
@@ -17,9 +15,9 @@ export const createMockPlayersResponse = (count: number, playerData: Array<{
       value: string | number;
     }>;
   };
-}>): YahooPlayersResponse => {
-  const players: YahooPlayersResponse['fantasy_content']['game'][1]['players'] = { count };
-  
+}>) => {
+  const players: Record<string, unknown> = { count };
+
   playerData.forEach((player, index) => {
     players[index.toString()] = {
       player: [
@@ -48,9 +46,9 @@ export const createMockPlayersResponse = (count: number, playerData: Array<{
 
 /**
  * Helper function to create empty Yahoo Players API response
- * @returns Empty YahooPlayersResponse with count: 0
+ * @returns Empty players response with count: 0
  */
-export const createEmptyPlayersResponse = (): YahooPlayersResponse => ({
+export const createEmptyPlayersResponse = () => ({
   fantasy_content: {
     game: [
       {},
@@ -82,4 +80,4 @@ export const createMockPlayerData = (overrides: Partial<{
   display_position: 'OF',
   player_stats: { stats: [] },
   ...overrides
-}); 
+});

--- a/src/app/api/dev/responses/route.ts
+++ b/src/app/api/dev/responses/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { getResponseLog, clearResponseLog, getLogsByEndpoint } from '@/lib/schemas/dev-logger';
+
+/**
+ * Development-only endpoint to view captured Yahoo API responses
+ * GET /api/dev/responses - Get all captured responses
+ * GET /api/dev/responses?endpoint=games - Filter by endpoint pattern
+ * DELETE /api/dev/responses - Clear all logs
+ */
+
+export async function GET(request: Request) {
+  if (process.env.NODE_ENV !== 'development') {
+    return NextResponse.json(
+      { error: 'This endpoint is only available in development mode' },
+      { status: 403 }
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const endpointFilter = searchParams.get('endpoint');
+
+  const logs = endpointFilter
+    ? getLogsByEndpoint(endpointFilter)
+    : getResponseLog();
+
+  return NextResponse.json({
+    count: logs.length,
+    logs
+  });
+}
+
+export async function DELETE() {
+  if (process.env.NODE_ENV !== 'development') {
+    return NextResponse.json(
+      { error: 'This endpoint is only available in development mode' },
+      { status: 403 }
+    );
+  }
+
+  clearResponseLog();
+
+  return NextResponse.json({ message: 'Logs cleared' });
+}

--- a/src/app/api/yahoo/route.ts
+++ b/src/app/api/yahoo/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import axios, { AxiosError } from 'axios';
+import { logResponse } from '@/lib/schemas/dev-logger';
 
 const YAHOO_FANTASY_BASE_URL = 'https://fantasysports.yahooapis.com/fantasy/v2';
 
@@ -27,29 +28,29 @@ export async function GET(request: Request) {
       }
     });
 
+    // Log response in development for schema building
+    logResponse(endpoint, response.data);
+
     return NextResponse.json(response.data);
   } catch (error: unknown) {
     if (error instanceof AxiosError) {
-      console.error('Yahoo API Error Details:', {
-        message: error.message,
-        status: error.response?.status,
-        statusText: error.response?.statusText,
-        data: error.response?.data,
-        headers: error.response?.headers
-      });
-
       return NextResponse.json(
-        { 
+        {
           error: 'Failed to fetch from Yahoo API',
-          details: error.response?.data || error.message
+          message: error.response?.data || error.message,
+          statusCode: error.response?.status || 500
         },
         { status: error.response?.status || 500 }
       );
     }
-    
+
     return NextResponse.json(
-      { error: 'An unexpected error occurred' },
+      {
+        error: 'An unexpected error occurred',
+        message: error instanceof Error ? error.message : 'Unknown error',
+        statusCode: 500
+      },
       { status: 500 }
     );
   }
-} 
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,8 +7,7 @@ import { AuthGuard } from "@/components/auth-guard";
 import { AppHeader } from "@/components/app-header";
 import { PageHeader } from "@/components/page-header";
 import { DataTable } from "@/components/players-table/data-table";
-import type { PlayerWithRank } from "@/types/yahoo-fantasy";
-import type { UserProfile } from "@/types/user-profile";
+import { extractUserProfile } from "@/lib/user-profile";
 
 export default function Home() {
   const { useUserInfo } = useYahooFantasy();
@@ -16,11 +15,7 @@ export default function Home() {
 
   const playersData = usePlayersManager();
   const currentSeason = new Date().getFullYear().toString();
-  const userProfile: UserProfile = {
-    displayName: userInfo?.fantasy_content?.users?.[0]?.user?.[1]?.profile?.display_name,
-    profileUrl: userInfo?.fantasy_content?.users?.[0]?.user?.[1]?.profile?.fantasy_profile_url,
-    imageUrl: userInfo?.fantasy_content?.users?.[0]?.user?.[1]?.profile?.image_url,
-  };
+  const userProfile = extractUserProfile(userInfo);
 
   return (
     <AuthGuard>
@@ -36,7 +31,7 @@ export default function Home() {
         />
         <DataTable 
           columns={playersData.columns} 
-          data={playersData.filteredPlayers as PlayerWithRank[]} 
+          data={playersData.filteredPlayers} 
           isLoading={playersData.isLoading}
           totalMatchingPlayers={playersData.totalMatchingPlayers}
           hasMore={playersData.hasMore}

--- a/src/lib/schemas/auth.ts
+++ b/src/lib/schemas/auth.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+/**
+ * Yahoo OAuth schemas
+ * Validates token responses and decoded JWTs from Yahoo
+ */
+
+// Decoded Yahoo ID token (JWT payload)
+export const yahooIdTokenSchema = z.object({
+  sub: z.string(),
+  aud: z.string(),
+  iss: z.string(),
+  exp: z.number(),
+  iat: z.number(),
+}).passthrough();
+
+export type YahooIdToken = z.infer<typeof yahooIdTokenSchema>;
+
+// Token response from Yahoo OAuth (initial token or refresh)
+// Uses passthrough() to allow additional fields like id_token
+export const yahooTokenResponseSchema = z.object({
+  access_token: z.string(),
+  refresh_token: z.string().optional(),
+  expires_in: z.number(),
+  token_type: z.string().optional(),
+  id_token: z.string().optional(),
+}).passthrough();
+
+export type YahooTokenResponse = z.infer<typeof yahooTokenResponseSchema>;
+
+// Error response from Yahoo OAuth
+export const yahooTokenErrorSchema = z.object({
+  error: z.string(),
+  error_description: z.string().optional(),
+}).passthrough();
+
+export type YahooTokenError = z.infer<typeof yahooTokenErrorSchema>;
+
+/**
+ * Parse Yahoo token response, distinguishing success from error
+ */
+export function parseYahooTokenResponse(data: unknown):
+  | { success: true; tokens: YahooTokenResponse }
+  | { success: false; error: YahooTokenError } {
+
+  // Check if it's an object with an error field (error responses)
+  if (data && typeof data === 'object' && 'error' in data && (data as Record<string, unknown>).error) {
+    const errorResult = yahooTokenErrorSchema.safeParse(data);
+    if (errorResult.success) {
+      return { success: false, error: errorResult.data };
+    }
+  }
+
+  // Try parsing as success (must have access_token)
+  const tokenResult = yahooTokenResponseSchema.safeParse(data);
+  if (tokenResult.success) {
+    return { success: true, tokens: tokenResult.data };
+  }
+
+  // Unknown response format
+  return {
+    success: false,
+    error: {
+      error: 'invalid_response',
+      error_description: `Unexpected response format from Yahoo OAuth: ${JSON.stringify(data)}`
+    }
+  };
+}

--- a/src/lib/schemas/dev-logger.ts
+++ b/src/lib/schemas/dev-logger.ts
@@ -1,0 +1,62 @@
+/**
+ * Development-only logger for capturing real Yahoo API responses
+ * Used to build accurate Zod schemas from actual data
+ *
+ * NEVER import this in production code paths
+ */
+
+const IS_DEV = process.env.NODE_ENV === 'development';
+const MAX_LOGS = 50;
+
+interface ResponseLog {
+  endpoint: string;
+  timestamp: string;
+  response: unknown;
+}
+
+// In-memory store for dev inspection
+const responseLog: ResponseLog[] = [];
+
+/**
+ * Log a Yahoo API response for later inspection
+ * Only works in development mode
+ */
+export function logResponse(endpoint: string, response: unknown): void {
+  if (!IS_DEV) return;
+
+  responseLog.push({
+    endpoint,
+    timestamp: new Date().toISOString(),
+    response
+  });
+
+  // Keep only last N responses to prevent memory issues
+  if (responseLog.length > MAX_LOGS) {
+    responseLog.shift();
+  }
+}
+
+/**
+ * Get all captured response logs
+ * Returns empty array in production
+ */
+export function getResponseLog(): ResponseLog[] {
+  return IS_DEV ? [...responseLog] : [];
+}
+
+/**
+ * Clear all captured logs
+ */
+export function clearResponseLog(): void {
+  if (IS_DEV) {
+    responseLog.length = 0;
+  }
+}
+
+/**
+ * Get logs for a specific endpoint pattern
+ */
+export function getLogsByEndpoint(pattern: string): ResponseLog[] {
+  if (!IS_DEV) return [];
+  return responseLog.filter(log => log.endpoint.includes(pattern));
+}

--- a/src/lib/schemas/env.ts
+++ b/src/lib/schemas/env.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+/**
+ * Environment variable validation schema
+ * Validates required env vars at application startup
+ */
+
+const envSchema = z.object({
+  // NextAuth
+  NEXTAUTH_URL: z.string().url(),
+  NEXTAUTH_SECRET: z.string().min(1),
+
+  // Yahoo OAuth
+  YAHOO_CLIENT_ID: z.string().min(1),
+  YAHOO_CLIENT_SECRET: z.string().min(1),
+
+  // Optional
+  NODE_ENV: z.enum(['development', 'production', 'test']).default('development'),
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+/**
+ * Validate environment variables
+ * Call this at app startup to fail fast on misconfiguration
+ */
+export function validateEnv(): Env {
+  const result = envSchema.safeParse(process.env);
+
+  if (!result.success) {
+    const errors = result.error.flatten().fieldErrors;
+    const missing = Object.entries(errors)
+      .map(([key, msgs]) => `  ${key}: ${msgs?.join(', ')}`)
+      .join('\n');
+
+    throw new Error(`Missing or invalid environment variables:\n${missing}`);
+  }
+
+  return result.data;
+}
+
+/**
+ * Get validated env vars (throws if invalid)
+ * Use this instead of accessing process.env directly
+ */
+let cachedEnv: Env | null = null;
+
+export function getEnv(): Env {
+  if (!cachedEnv) {
+    cachedEnv = validateEnv();
+  }
+  return cachedEnv;
+}

--- a/src/lib/schemas/games.ts
+++ b/src/lib/schemas/games.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+/**
+ * Yahoo Fantasy Sports API - Games endpoint schema
+ * Built from real API response: /games;game_codes=mlb;seasons={year}
+ *
+ * Key structure notes:
+ * - games is an object with numeric string keys ("0", "1", etc.), not an array
+ * - Each game entry contains a single-element array with game data
+ * - Includes count field and metadata fields
+ */
+
+// Individual game data
+export const gameDataSchema = z.object({
+  game_key: z.string(),
+  game_id: z.string(),
+  name: z.string(),
+  code: z.string(),
+  type: z.string(),
+  url: z.string(),
+  season: z.string(),
+  is_registration_over: z.number(),
+  is_game_over: z.number(),
+  is_offseason: z.number(),
+  alternate_start_deadline: z.string().optional()
+}).passthrough();
+
+// Game wrapper - Yahoo returns game data in single-element array
+export const gameWrapperSchema = z.object({
+  game: z.array(gameDataSchema).min(1)
+});
+
+// Games collection - object with numeric keys + count
+export const gamesCollectionSchema = z.record(
+  z.union([gameWrapperSchema, z.number()])
+).refine(
+  (data) => typeof data.count === 'number',
+  { message: 'Games collection must have count field' }
+);
+
+// Full games response
+export const gamesResponseSchema = z.object({
+  fantasy_content: z.object({
+    'xml:lang': z.string().optional(),
+    'yahoo:uri': z.string().optional(),
+    games: gamesCollectionSchema,
+    time: z.string().optional(),
+    copyright: z.string().optional(),
+    refresh_rate: z.string().optional()
+  }).passthrough()
+});
+
+export type GamesResponse = z.infer<typeof gamesResponseSchema>;
+export type GameData = z.infer<typeof gameDataSchema>;

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -3,7 +3,16 @@
  * Built from real API responses - see src/__tests__/fixtures/yahoo-responses.json
  */
 
+// API response schemas
 export * from './games';
 export * from './users';
 export * from './players';
+
+// Auth schemas
+export * from './auth';
+
+// Environment validation
+export { validateEnv, getEnv, type Env } from './env';
+
+// Dev utilities
 export { logResponse, getResponseLog, clearResponseLog, getLogsByEndpoint } from './dev-logger';

--- a/src/lib/schemas/index.ts
+++ b/src/lib/schemas/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Yahoo Fantasy Sports API Zod schemas
+ * Built from real API responses - see src/__tests__/fixtures/yahoo-responses.json
+ */
+
+export * from './games';
+export * from './users';
+export * from './players';
+export { logResponse, getResponseLog, clearResponseLog, getLogsByEndpoint } from './dev-logger';

--- a/src/lib/schemas/players.ts
+++ b/src/lib/schemas/players.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod';
+
+/**
+ * Yahoo Fantasy Sports API - Players endpoint schema
+ * Built from real API response: /game/{gameKey}/players;start=0;count=25;sort=AR;status=A;position=B/stats
+ *
+ * Key structure notes:
+ * - players is object with numeric keys ("0", "1", etc.) + count field
+ * - Each player entry has: player: [ [...metadata], { player_stats, player_advanced_stats } ]
+ * - Metadata array contains objects with single keys + empty arrays
+ * - Stats are wrapped: { stat: { stat_id, value } }
+ * - Stat values can be "-" (string) when no data, or numeric strings
+ */
+
+// Stat value - can be "-" for no data, or a number/numeric string
+export const statValueSchema = z.union([
+  z.string(),  // "-" or numeric string like "0.300"
+  z.number()
+]);
+
+// Individual stat entry - wrapped in { stat: {...} }
+export const statEntrySchema = z.object({
+  stat: z.object({
+    stat_id: z.string(),
+    value: statValueSchema
+  })
+});
+
+// Player stats container
+export const playerStatsContainerSchema = z.object({
+  '0': z.object({
+    coverage_type: z.string(),
+    season: z.string()
+  }).passthrough().optional(),
+  stats: z.array(statEntrySchema)
+}).passthrough();
+
+// Player name
+export const playerNameSchema = z.object({
+  full: z.string(),
+  first: z.string(),
+  last: z.string(),
+  ascii_first: z.string().optional(),
+  ascii_last: z.string().optional()
+});
+
+// Player metadata item - various single-key objects or empty arrays
+export const playerMetadataItemSchema = z.union([
+  z.object({ player_key: z.string() }).passthrough(),
+  z.object({ player_id: z.string() }).passthrough(),
+  z.object({ name: playerNameSchema }).passthrough(),
+  z.object({ url: z.string() }).passthrough(),
+  z.object({ status: z.string(), status_full: z.string() }).passthrough(), // Inactive players
+  z.object({ editorial_player_key: z.string() }).passthrough(),
+  z.object({ editorial_team_key: z.string() }).passthrough(),
+  z.object({ editorial_team_full_name: z.string() }).passthrough(),
+  z.object({ editorial_team_abbr: z.string() }).passthrough(),
+  z.object({ editorial_team_url: z.string() }).passthrough(),
+  z.object({ display_position: z.string() }).passthrough(),
+  z.object({ position_type: z.string() }).passthrough(),
+  z.object({ uniform_number: z.string() }).passthrough(),
+  z.object({ headshot: z.unknown() }).passthrough(),
+  z.object({ eligible_positions: z.array(z.unknown()) }).passthrough(),
+  z.object({ eligible_positions_to_add: z.array(z.unknown()) }).passthrough(),
+  z.object({ is_keeper: z.unknown() }).passthrough(),
+  z.object({ is_undroppable: z.string() }).passthrough(),
+  z.object({ has_player_notes: z.number() }).passthrough(),
+  z.array(z.unknown()),  // Empty arrays that appear in metadata
+  z.record(z.unknown())  // Catch-all for other objects
+]);
+
+// Player stats wrapper (second element of player tuple)
+export const playerStatsWrapperSchema = z.object({
+  player_stats: playerStatsContainerSchema.optional(),
+  player_advanced_stats: playerStatsContainerSchema.optional()
+}).passthrough();
+
+// Full player entry
+export const playerEntrySchema = z.object({
+  player: z.tuple([
+    z.array(playerMetadataItemSchema),  // Metadata array
+    playerStatsWrapperSchema            // Stats object
+  ])
+});
+
+// Players collection - object with numeric keys + count
+export const playersCollectionSchema = z.record(
+  z.union([playerEntrySchema, z.number()])
+);
+
+// Game data in players response (first element of game tuple)
+export const gameInfoSchema = z.object({
+  game_key: z.string(),
+  game_id: z.string(),
+  name: z.string(),
+  code: z.string(),
+  type: z.string(),
+  url: z.string(),
+  season: z.string(),
+  is_registration_over: z.number(),
+  is_game_over: z.number(),
+  is_offseason: z.number()
+}).passthrough();
+
+// Players wrapper (second element of game tuple)
+export const playersWrapperSchema = z.object({
+  players: playersCollectionSchema
+});
+
+// Full players response
+export const playersResponseSchema = z.object({
+  fantasy_content: z.object({
+    'xml:lang': z.string().optional(),
+    'yahoo:uri': z.string().optional(),
+    game: z.tuple([
+      gameInfoSchema,
+      playersWrapperSchema
+    ]),
+    time: z.string().optional(),
+    copyright: z.string().optional(),
+    refresh_rate: z.string().optional()
+  }).passthrough()
+});
+
+export type PlayersResponse = z.infer<typeof playersResponseSchema>;
+export type PlayerEntry = z.infer<typeof playerEntrySchema>;
+export type PlayerStatsContainer = z.infer<typeof playerStatsContainerSchema>;

--- a/src/lib/schemas/users.ts
+++ b/src/lib/schemas/users.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+/**
+ * Yahoo Fantasy Sports API - Users endpoint schema
+ * Built from real API response: /users;use_login=1/profile
+ *
+ * Key structure notes:
+ * - users is an object with numeric string keys ("0"), not an array
+ * - Each user entry has array: [{ guid }, { profile: {...} }]
+ * - Profile contains display_name, image_url, etc.
+ */
+
+// User profile data
+export const userProfileSchema = z.object({
+  display_name: z.string(),
+  fantasy_profile_url: z.string(),
+  legal_jurisdiction: z.string().optional(),
+  image_url: z.string(),
+  unique_username: z.string().optional()
+}).passthrough();
+
+// User entry - array with guid object and profile object
+export const userEntrySchema = z.object({
+  user: z.array(
+    z.union([
+      z.object({ guid: z.string() }).passthrough(),
+      z.object({ profile: userProfileSchema }).passthrough()
+    ])
+  ).min(1)
+});
+
+// Users collection - object with numeric keys + count
+export const usersCollectionSchema = z.record(
+  z.union([userEntrySchema, z.number()])
+).refine(
+  (data) => typeof data.count === 'number',
+  { message: 'Users collection must have count field' }
+);
+
+// Full users response
+export const usersResponseSchema = z.object({
+  fantasy_content: z.object({
+    'xml:lang': z.string().optional(),
+    'yahoo:uri': z.string().optional(),
+    users: usersCollectionSchema,
+    time: z.string().optional(),
+    copyright: z.string().optional(),
+    refresh_rate: z.string().optional()
+  }).passthrough()
+});
+
+export type UsersResponse = z.infer<typeof usersResponseSchema>;
+export type UserProfile = z.infer<typeof userProfileSchema>;

--- a/src/lib/user-profile.ts
+++ b/src/lib/user-profile.ts
@@ -1,0 +1,26 @@
+import type { UsersResponse } from '@/lib/schemas/users';
+import type { UserProfile } from '@/types/user-profile';
+
+interface YahooProfile {
+  display_name?: string;
+  fantasy_profile_url?: string;
+  image_url?: string;
+}
+
+/**
+ * Extracts user profile from Yahoo's nested API response structure.
+ * Users collection uses numeric string keys ("0", "1"), not array indices.
+ */
+export function extractUserProfile(userInfo: UsersResponse | undefined): UserProfile {
+  const firstUser = userInfo?.fantasy_content?.users?.["0"];
+  if (typeof firstUser === 'number') return {};
+
+  const profileEntry = firstUser?.user?.[1];
+  const profile = (profileEntry && 'profile' in profileEntry ? profileEntry.profile : undefined) as YahooProfile | undefined;
+
+  return {
+    displayName: profile?.display_name,
+    profileUrl: profile?.fantasy_profile_url,
+    imageUrl: profile?.image_url,
+  };
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -5,20 +5,6 @@ export interface YahooProfile {
   picture?: string;
 }
 
-export interface YahooIdToken {
-  sub: string;
-  aud: string;
-  iss: string;
-  exp: number;
-  iat: number;
-}
-
-export interface YahooTokens {
-  access_token: string;
-  refresh_token?: string;
-  expires_in: number;
-}
-
 import type { DefaultSession } from "next-auth";
 
 export interface ExtendedSession extends DefaultSession {

--- a/src/types/yahoo-fantasy.ts
+++ b/src/types/yahoo-fantasy.ts
@@ -1,34 +1,3 @@
-export interface YahooUserResponse {
-  fantasy_content: {
-    users: Array<{
-      user: Array<{
-        profile?: {
-          display_name: string;
-          fantasy_profile_url: string;
-          image_url: string;
-        };
-      }>;
-    }>;
-  };
-}
-
-export interface YahooGameKey {
-  game_key: string;
-  game_id: string;
-  name: string;
-  code: string;
-  type: string;
-  season: string;
-}
-
-export interface YahooGamesResponse {
-  fantasy_content: {
-    games: Array<{
-      game: [YahooGameKey, unknown];
-    }>;
-  };
-}
-
 export interface YahooPlayerStats {
   player_key: string;
   name: {
@@ -43,37 +12,12 @@ export interface YahooPlayerStats {
       stat_id: number;
       value: string | number;
     }>;
+    byStatId?: Record<number, string | number>;
   };
 }
 
 // Extended player type with preserved original ranking and current global rank for table display
-export type PlayerWithRank = YahooPlayerStats & { 
+export type PlayerWithRank = YahooPlayerStats & {
   originalRank: number;  // Yahoo's original performance ranking (sort=AR order)
   globalRank: number;    // Current position in filtered/searched results
 }
-
-export interface YahooPlayersResponse {
-  fantasy_content: {
-    game: [
-      unknown,
-      {
-        players: {
-          count: number;
-          [key: string]: {
-            player: [
-              Array<Record<string, unknown>>,
-              {
-                player_stats?: {
-                  stats: Array<{
-                    stat_id: number;
-                    value: string | number;
-                  }>;
-                };
-              }
-            ];
-          } | number;
-        };
-      }
-    ];
-  };
-} 


### PR DESCRIPTION
## Summary
- Add Zod schemas for Yahoo API responses (games, users, players endpoints)
- Add Zod validation for OAuth tokens and JWT decoding
- Add environment variable validation with fail-fast behavior
- Remove redundant TypeScript interfaces now handled by Zod
- Update documentation (CLAUDE.md, AGENTS.md, SKILL.md) with implementation details

## Key Changes
- `src/lib/schemas/` - New Zod schemas for all external data boundaries
- `src/lib/yahoo-fantasy.ts` - Integrated `requestWithValidation()` method
- `src/lib/auth.ts` - OAuth token validation with `parseYahooTokenResponse()`
- `src/lib/schemas/env.ts` - Environment variable validation
- Dev endpoint `/api/dev/responses` for capturing real API responses during development

## Test plan
- [x] Verified login/OAuth flow works
- [x] Verified player data table renders correctly
- [x] Verified `npm run lint` passes
- [x] Verified TypeScript compilation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)