### PR TITLE
Group ESLint packages in Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,17 @@ updates:
       interval: "weekly"
       day: "monday"
     groups:
+      eslint:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
       dev-dependencies:
         dependency-type: "development"
+        exclude-patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@eslint/*"
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary
Configure Dependabot to bundle ESLint-related packages together so major version bumps only succeed when all plugins support the new version.

## Problem
Dependabot bumped ESLint to v10, but `eslint-plugin-react` only supports up to v9.7 ([jsx-eslint/eslint-plugin-react#3977](https://github.com/jsx-eslint/eslint-plugin-react/issues/3977)). This caused CI failures in PR #48.

## Solution
Add an `eslint` group in `.github/dependabot.yml` that bundles:
- `eslint`
- `eslint-*` (e.g., `eslint-plugin-react`, `eslint-config-next`)
- `@eslint/*` (e.g., `@eslint/js`, `@eslint/eslintrc`)

These packages are excluded from the general dev-dependencies group to avoid duplicate PRs.

## Impact
- ESLint major version bumps will now be grouped with plugin updates
- If a plugin doesn't support the new ESLint version, CI fails and the PR stays open until compatibility is released
- No manual monitoring needed - Dependabot will automatically retry

🤖 Generated with [Claude Code](https://claude.ai/code)